### PR TITLE
Update for Kaleidoscope `KeyEvent` changes, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,20 @@ including the header file, and declaring it used:
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-KeyLogger.h>
 
-KALEIDOSCOPE_INIT_USER(KeyLogger);
+KALEIDOSCOPE_INIT_PLUGINS(KeyLogger);
 
 void setup() {
   Serial.begin(9600);
-  Kaleidoscope.setup ();
+  Kaleidoscope.setup();
 }
 ```
 
 That, in itself, will do all that is necessary to have the key logger active.
+
+Note: For most accurate physical keypress data, KeyLogger should be the first
+plugin in `KALEIDOSCOPE_INIT_PLUGINS()`, but if other plugins that change the
+value of keys (e.g. Qukeys, TapDance, Leader, etc.) are also being used, it may
+be useful to change the plugin order.
 
 ## The output
 
@@ -43,8 +48,8 @@ Monitor* built into the Arduino IDE), one will be able to see the following
 output:
 
 ```
-KL: row=1, col=2, pressed=1, defaultLayer=0, layerState=1, mappedKey.flags=0, mappedKey.keyCode=ff
-KL: row=1, col=2, pressed=0, defaultLayer=0, layerState=1, mappedKey.flags=0, mappedKey.keyCode=ff
+KL: row=1, col=2, pressed=1, layer=0, key_flags=0, key_code=FF
+KL: row=1, col=2, pressed=0, layer=0, key_flags=0, key_code=FF
 ```
 
 ## Further reading

--- a/examples/KeyLogger/KeyLogger.ino
+++ b/examples/KeyLogger/KeyLogger.ino
@@ -42,7 +42,6 @@ KEYMAPS(
 KALEIDOSCOPE_INIT_PLUGINS(KeyLogger);
 
 void setup() {
-  Serial.begin(9600);
   Kaleidoscope.setup();
 }
 

--- a/examples/KeyLogger/KeyLogger.ino
+++ b/examples/KeyLogger/KeyLogger.ino
@@ -19,7 +19,7 @@
 #include <Kaleidoscope-KeyLogger.h>
 
 // *INDENT-OFF*
-const Key keymaps[][ROWS][COLS] PROGMEM = {
+KEYMAPS(
   [0] = KEYMAP_STACKED
   (Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
    Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
@@ -36,7 +36,7 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 
    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
    Key_NoKey),
-};
+)
 // *INDENT-ON*
 
 KALEIDOSCOPE_INIT_PLUGINS(KeyLogger);

--- a/examples/KeyLogger/KeyLogger.ino
+++ b/examples/KeyLogger/KeyLogger.ino
@@ -21,10 +21,10 @@
 // *INDENT-OFF*
 const Key keymaps[][ROWS][COLS] PROGMEM = {
   [0] = KEYMAP_STACKED
-  (Key_NoKey, Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
-   Key_Backtick,      Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
-   Key_PageUp,        Key_A, Key_S, Key_D, Key_F, Key_G,
-   Key_PageDown,      Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+  (Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
+   Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+   Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
+   Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
 
    Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
    Key_NoKey,

--- a/examples/KeyLogger/sketch.json
+++ b/examples/KeyLogger/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:model01",
+    "port": ""
+  }
+}

--- a/src/Kaleidoscope-KeyLogger.cpp
+++ b/src/Kaleidoscope-KeyLogger.cpp
@@ -39,7 +39,7 @@ EventHandlerResult KeyLogger::onKeyswitchEvent(KeyEvent &event) {
   Runtime.serialPort().print(F(", pressed="));
   Runtime.serialPort().print(keyToggledOn(event.state), DEC);
   Runtime.serialPort().print(F(", layer="));
-  Runtime.serialPort().print(Layer.lookupActiveLayer(event.addr), BIN);
+  Runtime.serialPort().print(Layer.lookupActiveLayer(event.addr), DEC);
   Runtime.serialPort().print(F(", key_flags="));
   Runtime.serialPort().print(event.key.getFlags(), BIN);
   Runtime.serialPort().print(F(", key_code="));

--- a/src/Kaleidoscope-KeyLogger.h
+++ b/src/Kaleidoscope-KeyLogger.h
@@ -19,14 +19,17 @@
 
 #include <Kaleidoscope.h>
 
+#include "kaleidoscope/KeyEventTracker.h"
+
 namespace kaleidoscope {
 namespace plugin {
 
 class KeyLogger : public kaleidoscope::Plugin {
  public:
-  KeyLogger(void) {};
+  EventHandlerResult onKeyswitchEvent(KeyEvent &event);
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
+ private:
+  KeyEventTracker event_tracker_;
 };
 
 }


### PR DESCRIPTION
This bundles a bunch of other updates, in addition to changes for `KeyEvent` handlers:

- Update to arduino-cli build system
- Use the `KEYMAPS()` macro in the example sketch
- Use `Runtime.serialPort()` instead of `Serial`
- Use `Runtime.millisAtCycleStart()` instead of `millis()`
- Add a `KeyEventTracker`
- Report the layer a key is mapped from instead of layer state
- Change output so that it no longer matches old event handler code
- Add note to README about plugin registration order
